### PR TITLE
Added tag heights file name to Fiducials__create().

### DIFF
--- a/src/fiducials_localization.cpp
+++ b/src/fiducials_localization.cpp
@@ -194,8 +194,7 @@ void imageCallback(const sensor_msgs::ImageConstPtr & msg) {
         if(fiducials == NULL) {
             ROS_INFO("Git first image! Setting up Fiducials library");
             fiducials = Fiducials__create(image, NULL, NULL, location_announce,
-	      tag_announce, NULL, NULL);
-            Fiducials__tag_heights_xml_read(fiducials, tag_height_file.c_str());
+	    tag_announce, NULL, "Map.xml", tag_height_file.c_str());
         }
         Fiducials__image_set(fiducials, image);
         Fiducials__process(fiducials);


### PR DESCRIPTION
Added tag heights file name to Fiducials__create() and removed separate call for Fiducials__tag_heights_xml_file_read().  This was necessary so that the Map__restore() routine could read in the XML heights.
